### PR TITLE
Adapted the cypress tests for Home Office kit

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -8,7 +8,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl">
         Prototype your service with the Home Office styled GOV.UK prototype kit
         <span class="govuk-caption-l">Based on <a href="https://github.com/alphagov/govuk_prototype_kit">govuk_prototype_kit</a> {{releaseVersion}}</span>
       </h1>{{releaseVersion | log }}

--- a/cypress/integration/1-watch-files/watch-styles.cypress.js
+++ b/cypress/integration/1-watch-files/watch-styles.cypress.js
@@ -9,7 +9,7 @@ const backupAppStylesheet = 'cypress/temp/temp-application.scss'
 describe('watch sass files', () => {
   describe(`sass file ${cypressTestStylePattern} should be created and included within the ${appStylesheet} and accessible from the browser as /${publicStylesheet}`, () => {
     const cssStatement = `
-    .govuk-header { background: red; }
+    .hods-header { background: red; }
     `
 
     before(() => {
@@ -24,13 +24,13 @@ describe('watch sass files', () => {
 
       cy.task('deleteFile', { filename: cypressTestStylePattern })
 
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(11, 12, 12)')
+      cy.get('.hods-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(255, 255, 255)')
       cy.task('deleteFile', { filename: backupAppStylesheet })
     })
 
     it('The colour of the header should be change to red then back to black', () => {
       cy.task('log', 'The colour of the header should be black')
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(11, 12, 12)')
+      cy.get('.hods-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(255, 255, 255)')
 
       cy.task('log', `Create ${cypressTestStylePattern}`)
       cy.task('createFile', {
@@ -47,7 +47,7 @@ describe('watch sass files', () => {
       })
 
       cy.task('log', 'The colour of the header should be changed to red')
-      cy.get('.govuk-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(255, 0, 0)')
+      cy.get('.hods-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(255, 0, 0)')
     })
   })
 })

--- a/cypress/integration/utils.js
+++ b/cypress/integration/utils.js
@@ -7,7 +7,7 @@ const waitForApplication = async () => {
   cy.task('waitUntilAppRestarts')
   cy.visit(hostName)
   cy.get('h1.govuk-heading-xl', { timeout: 20000 })
-    .should('contains.text', 'Prototype your service using GOV.UK Prototype Kit')
+    .should('contains.text', 'Prototype your service')
 }
 
 module.exports = {


### PR DESCRIPTION
Cypress integration tests introduced in the GOV.UK kit 12.1.0 initially failed when introduced to the Home Office design kit (https://github.com/UKHomeOffice/home_office_design_kit/pull/13).

This seeks to adapt the tests to work in the Home Office context. This means:

- changing the load criteria to the Home Office header text on the index page
- changing the header style on the index page to xl
- adapting the style check to use the default header background colour of white, rather than the gov.uk black