### PR TITLE
Update styling to allow GOV.UK prototype kit update process to work

### DIFF
--- a/__tests__/spec/start.js
+++ b/__tests__/spec/start.js
@@ -37,7 +37,7 @@ describe('npm start', () => {
 
       const app = child_process.spawnSync(
         'node lib/build/dev-server',
-        { cwd: testDir, encoding: 'utf8', shell: true, timeout: 2500 }
+        { cwd: testDir, encoding: 'utf8', shell: true, timeout: 5000 }
       )
 
       expect(app).toEqual(expect.objectContaining({

--- a/app/assets/sass/application-ie8.scss
+++ b/app/assets/sass/application-ie8.scss
@@ -1,3 +1,3 @@
 $govuk-is-ie8: true;
 
-@import "application";
+@import "ho-application";

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -1,7 +1,6 @@
 // global styles for <a> and <p> tags
 $govuk-global-styles: true;
 $govuk-new-link-styles: true;
-$govuk-font-family: inherit;
 
 // We can't mount GOV.UK Frontend's assets at root as it's done automatically by the extensions framework.
 $govuk-assets-path: '/govuk/assets/';
@@ -22,51 +21,47 @@ $govuk-assets-path: '/govuk/assets/';
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
 
-////////////////////////////////////////
-// HOD PATTERN LIBRARY STYLES
-// Extend the GOV.UK patterns for additional use cases and users, including internal services.
-// https://home-office-digital-patterns.herokuapp.com
-//////////
+/*
+  // Legacy Home Office Design Patterns
+  // If you want to use these remove line 24 and 67
+  // Extend the GOV.UK patterns for additional use cases and users, including internal services.
+  // https://home-office-digital-patterns.herokuapp.com
+  //////////
 
-// Compatibility
-// (It seems that we still need govuk-elements-sass.)
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_colours.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_font_stack.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_measurements.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_conditionals.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_device-pixels.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_grid_layout.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_typography.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/_shims.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_breadcrumbs.scss";
-@import "node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss";
-@import "node_modules/govuk-elements-sass/public/sass/_elements.scss"; 
+  // Compatibility
+  // (It seems that we still need govuk-elements-sass.)
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_colours.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_font_stack.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_measurements.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_conditionals.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_device-pixels.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_grid_layout.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_typography.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/_shims.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_breadcrumbs.scss";
+  @import "node_modules/govuk_frontend_toolkit/stylesheets/design-patterns/_buttons.scss";
+  @import "node_modules/govuk-elements-sass/public/sass/_elements.scss";
 
-// Variables (setting measurements for HO patterns)
-$space-sm: 5px;
-$border-radius: 4px;
-$box-shadow: 0 2px 10px rgba($text-colour, 0.5);
-//////////
+  // Variables (setting measurements for HO patterns)
+  $space-sm: 5px;
+  $border-radius: 4px;
+  $box-shadow: 0 2px 10px rgba($text-colour, 0.5);
 
-// Copmonents
-@import "_hod-components/badges";
-@import "_hod-components/buttons";
-@import "_hod-components/cards";
-@import "_hod-components/labels";
-//////////
+  // Copmonents
+  @import "_hod-components/badges";
+  @import "_hod-components/buttons";
+  @import "_hod-components/cards";
+  @import "_hod-components/labels";
 
-// Patterns
-@import "_hod-patterns/flashcard";
-@import "_hod-patterns/highlights";
-@import "_hod-patterns/modal";
-@import "_hod-patterns/navigation";
-@import "_hod-patterns/table-multiselect";
-@import "_hod-patterns/tabs";
-@import "_hod-patterns/tasks";
-@import "_hod-patterns/timeline";
-//////////
-////////////////////////////////////////
+  // Patterns
+  @import "_hod-patterns/flashcard";
+  @import "_hod-patterns/highlights";
+  @import "_hod-patterns/modal";
+  @import "_hod-patterns/navigation";
+  @import "_hod-patterns/table-multiselect";
+  @import "_hod-patterns/tabs";
+  @import "_hod-patterns/tasks";
+  @import "_hod-patterns/timeline";
 
-@import "roboto";
-@import "home-office/all";
+*/

--- a/app/assets/sass/ho-application.scss
+++ b/app/assets/sass/ho-application.scss
@@ -1,0 +1,13 @@
+// global styles for how the font works
+$govuk-font-family: inherit;
+
+// If you want to use legacy patterns, uncomment the section in application.scss
+@import "application";
+
+// Roboto is the Home Office font
+@import "roboto";
+
+// Imports all of the Home Office components (https://design.homeoffice.gov.uk/components)
+@import "home-office/all";
+
+// Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -1,5 +1,5 @@
 <!--[if lte IE 8]><link href="/public/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
-<!--[if gt IE 8]><!--><link href="/public/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<!--[if gt IE 8]><!--><link href="/public/stylesheets/ho-application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 
 {% for stylesheetUrl in extensionConfig.stylesheets %}
   <link href="{{ stylesheetUrl }}" rel="stylesheet" type="text/css" />

--- a/cypress/integration/1-watch-files/watch-styles.cypress.js
+++ b/cypress/integration/1-watch-files/watch-styles.cypress.js
@@ -3,10 +3,10 @@ const path = require('path')
 const { waitForApplication } = require('../utils')
 
 const appStyles = path.join(Cypress.env('projectFolder'), 'app', 'assets', 'sass')
-const appStylesheet = path.join(appStyles, 'application.scss')
+const appStylesheet = path.join(appStyles, 'ho-application.scss')
 const cypressTestStyles = 'cypress-test'
 const cypressTestStylePattern = `${appStyles}/patterns/_${cypressTestStyles}.scss`
-const publicStylesheet = 'public/stylesheets/application.css'
+const publicStylesheet = 'public/stylesheets/ho-application.css'
 const backupAppStylesheet = path.join(Cypress.env('tempFolder'), 'temp-application.scss')
 
 describe('watch sass files', () => {
@@ -31,8 +31,8 @@ describe('watch sass files', () => {
       cy.task('deleteFile', { filename: backupAppStylesheet })
     })
 
-    it('The colour of the header should be change to red then back to black', () => {
-      cy.task('log', 'The colour of the header should be black')
+    it('The colour of the header should be change to red then back to white', () => {
+      cy.task('log', 'The colour of the header should be white')
       cy.get('.hods-header', { timeout: 20000 }).should('have.css', 'background-color', 'rgb(255, 255, 255)')
 
       cy.task('log', `Create ${cypressTestStylePattern}`)


### PR DESCRIPTION
Creates `ho-application.scss`, which changes the default `font-family` to `inherit`.

This means that the instructions https://govuk-prototype-kit.herokuapp.com/docs/updating-the-kit, including updating the `application.scss` will work and maintain the Home Office styles.